### PR TITLE
Improving login error handling and display

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -51,6 +51,9 @@ body, html{ background: #252830; color:#fff; }
 #login{ display: none; padding-top:30px; }
 #terminal{ display: none; }
 
+/* Login Form */
+#login_error{ display: none; }
+
 /* Terminal Areas */
 #header,#footer,#content{
   color:#fff;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -22,10 +22,10 @@ $(function() {
     }
   });
 
-  do_login();
+  do_login(true);
 
-  function do_login(){
-    login()
+  function do_login(firstRun){
+    login(firstRun)
       .then(get_devices)
       .then(update_devices)
       .then(get_devinfo)
@@ -35,12 +35,14 @@ $(function() {
       .catch(function(err){ console.warn('Error: ', err); });
   }
 
-  function login(){
+  function login(firstRun){
+    $('#login_error').hide();
+
     if(!access_token){
       var email = $('#login_email').val();
       var pass = $('#login_password').val();
 
-      if(email && pass){
+      if(!firstRun){
         return particle.login({
           username: email,
           password: pass
@@ -74,8 +76,6 @@ $(function() {
   function login_success(data){
     $('#login_button').attr('disabled',false);
     $('#login_error').hide();
-    $('#login_email').val("");
-    $('#login_password').val("");
 
     if(data.body.access_token){
       access_token = data.body.access_token;
@@ -88,9 +88,13 @@ $(function() {
 
   function login_err(err){
     $('#login_button').attr('disabled',false);
-    $('#login_password').val("");
-    $('#login_error').html(err.errorDescription);
+    $('#login_error').html(err.errorDescription.split(' - ')[1]);
     $('#login_error').show();
+
+    if(err.body.error == 'invalid_token'){
+      localStorage.removeItem("access_token");
+    }
+
     show_login();
   }
 

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
       </div>
 
       <div class="col-md-4 col-md-offset-4 center">
-        <form autocomplete="on" method="POST">
+        <form id="login_form" autocomplete="on" method="POST">
           <fieldset class="form-group">
             <input name="email" type="email" class="form-control" id="login_email" placeholder="Particle Login email">
           </fieldset>
@@ -43,10 +43,13 @@
             <input name="password" type="password" class="form-control" id="login_password" placeholder="Particle Password">
           </fieldset>
 
-          <div id="login_error" style="color:red;font-weight:bold;display:none;">Invalid email or password.</div>
+          <fieldset class="form-group">
+            <button class="btn btn-primary" id="login_button">Log In</button>
+          </fieldset>
 
-          <button class="btn btn-primary" id="login_button">Log In</button>
-
+          <fieldset class="form-group">
+            <div id="login_error" class="alert alert-danger" role="alert">Invalid email or password.</div>
+          </fieldset>
         </form>
       </div>
     </div>


### PR DESCRIPTION
Login errors now propagate from the API to an alert box on the login form.

There are a few possible states when starting the app: no access token, invalid access token, or valid access token. This is handled in `login()` but if in the particular state where there is no access token, we don't want to submit an empty form right away, which induces an error when the user hasn't done anything yet.

To mitigate this, `do_login()` is now called with a `firstRun` value of `true`, which will prevent an empty login attempt while still allowing the `do_login()` promise chain to run through properly.

Reference: https://github.com/kh90909/OakTerm/issues/11
