### PR TITLE
Implementing offcanvas mobile sidebar

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -5,6 +5,8 @@ body, html{ background: #252830; color:#fff; }
 .center{ text-align: center; }
 
 /* Bootstrap Overrides */
+body::-webkit-scrollbar,
+.fixed-sidebar::-webkit-scrollbar{ display: none }
 .form-control {
   display: block;
   width: 100%;
@@ -32,6 +34,8 @@ body, html{ background: #252830; color:#fff; }
   padding-top:70px;
   padding-bottom:70px;
   height:100%;
+  overflow-y:scroll;
+  z-index: 1;
 }
 .fixed-sidebar .form-control{
   max-width:90%;
@@ -74,11 +78,11 @@ body, html{ background: #252830; color:#fff; }
   border-top: 1px gray solid;
   padding-top: .5em;
   padding-bottom: .5em;
-
   position: fixed;
   bottom:0;
   left:0;
   width:100%;
+  z-index: 2;
 }
 #content{
   font-family: Consolas, monospace, sans-serif;
@@ -91,10 +95,46 @@ body, html{ background: #252830; color:#fff; }
   background-color: #1f8dd6;
   color: white;
 }
-.text_stdin     { color: #808080;  }
+.text_stdin     { color: #808080; }
 .text_stdout    { color: #ffffff; }
-.text_stderr    { color: #d9534f;   }
-.text_event     { color: #DCDC00;}
-.text_sentevent { color: #f0ad4e;}
-.text_variable  { color: #5bc0de;  }
-.text_function  { color: #5cb85c;  }
+.text_stderr    { color: #d9534f; }
+.text_event     { color: #DCDC00; }
+.text_sentevent { color: #f0ad4e; }
+.text_variable  { color: #5bc0de; }
+.text_function  { color: #5cb85c; }
+
+/* Sidebar and Controls */
+#show-sidebar{
+  color:#fff;
+  font-size:2rem;
+  z-index: 1;
+}
+
+/* Responsive */
+@media (max-width: 768px){
+  .sm-center{ text-align: center; }
+  .sm-align-right{ text-align: right; }
+
+  .fixed-sidebar{
+    transform:translateX(-100%);
+    transition: transform 0.2s ease-out;
+    min-width:50%;
+  }
+  .fixed-sidebar.open{
+    transform:translateX(0%);
+  }
+  #footer > div[class^="col-"]{ margin:3px 0;}
+}
+@media (max-width: 544px){
+  .xs-center{ text-align: center; }
+  .xs-align-right{ text-align: right; }
+  #show-sidebar{
+    position: absolute;
+    top:5px;
+    left:10px;
+  }
+  .fixed-sidebar{
+    width:100%;
+  }
+
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -221,6 +221,20 @@ $(function() {
       .then(update_devinfo);
   });
 
+  $('#sidebar').hover(function(){
+    $('body').css('overflow', 'hidden');
+  }, function(){
+    $('body').css('overflow', 'auto')
+  });
+
+  $('#show-sidebar').on('click touch', function(){
+    $('.fixed-sidebar').toggleClass('open');
+  });
+
+  $('#file-btn').click(function(){
+    $('#file-input').click();
+  })
+
   setInterval(function(){
     console.log('Update device list timer');
     get_devices()
@@ -239,6 +253,11 @@ function set_heights(){
   var footerHeight = $("#footer").outerHeight(true);
   $("#content").css('padding-top', headerHeight+10);
   $("#content").css('padding-bottom', footerHeight+10);
+
+  if($(window).width() < 768){
+    $('.fixed-sidebar').css('padding-top', headerHeight+10)
+    $('.fixed-sidebar').css('padding-bottom', footerHeight+10)
+  }
 }
 
 $(window).resize(set_heights);

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -227,7 +227,8 @@ $(function() {
     $('body').css('overflow', 'auto')
   });
 
-  $('#show-sidebar').on('click touch', function(){
+  $('#show-sidebar').on('click touch', function(e){
+    e.preventDefault();
     $('.fixed-sidebar').toggleClass('open');
   });
 

--- a/index.html
+++ b/index.html
@@ -53,11 +53,13 @@
 
     <div id="terminal" class="clearfix">
       <nav id="header" class=" navbar-fixed-top container-fluid">
-        <div class="col-md-3">
+        <a href="#" id="show-sidebar" class="hidden-md-up col-sm-1"><i class="fa fa-bars"></i></a>
+
+        <div class="col-md-3 col-sm-4 col-xs-12 xs-center">
           <h1>OakTerm</h1>
         </div>
 
-        <form class="form-inline col-md-6">
+        <div class="col-md-4 col-sm-7 col-xs-12 sm-align-right xs-center">
           <button class="btn btn-success" id="refresh" data-toggle="tooltip" data-placement="bottom" title="Refresh">
             <i class="fa fa-refresh"></i></button>
           <button class="btn btn-secondary" id="sendevent" data-toggle="tooltip" data-placement="bottom" title="Send Event">
@@ -68,18 +70,20 @@
             <i class="fa fa-cogs"></i></button>
           <button class="btn btn-warning" id="usermode" data-toggle="tooltip" data-placement="bottom" title="User Mode">
             <i class="fa fa-user-secret"></i></button>
-        </form>
+          <button class="btn btn-default hidden-md-up" id="file-btn" data-toggle="tooltip" data-placement="bottom" title="Upload File">
+            <i class="fa fa-upload"></i></button>
+        </div>
 
-        <form class="form-inline col-md-3">
+        <form class="form-inline col-md-3 hidden-sm-down">
           <label class="file">
-            <input type="file" id="file">
+            <input type="file" id="file-input">
             <span class="file-custom"></span>
           </label>
         </form>
       </nav>
 
       <div class="container-fluid">
-        <div id="sidebar" class="col-md-3 fixed-sidebar">
+        <div id="sidebar" class="col-md-3 fixed-sidebar" >
           <fieldset class="form-group">
             <label for="deviceIDs">Device: </label> <span class="label label-danger" id="devstatus">offline</span>
             <select id="deviceIDs" class="form-control">
@@ -129,15 +133,15 @@
       </div>
 
       <footer id="footer" class="container-fluid">
-        <div class="col-md-9">
+        <div class="col-md-8">
           <input type="text" class="form-control" id="senddata" placeholder="Send Data">
         </div>
 
-        <div class="col-sm-1">
+        <div class="col-md-2 col-xs-6">
           <button id="send" type="submit" class="btn btn-success"><i class="fa fa-paper-plane"></i> Send Data</button>
         </div>
 
-        <div class="col-md-2 align-right">
+        <div class="col-md-2 col-sm-6 align-right sm-align-right">
           <button class="btn btn-info" data-toggle="tooltip" data-placement="top" title="Settings">
             <i class="fa fa-cog"></i></button>
           <button class="btn btn-secondary" id="logout" data-toggle="tooltip" data-placement="top" title="Sign Out">


### PR DESCRIPTION
Adds an off-canvas sidebar for mobile resolutions, triggered by a header menu icon.

Scrolling behavior has been tested when both terminal and sidebar content are longer than the screen. Naturally, when scrolling the sidebar and the scroll hits the bottom, the main terminal content starts scrolling. This may or may not be acceptable behavior, but a patch has been implemented that prevents this from happening. When hovering (or dragging) the sidebar, the HTML body is set to `overflow:hidden` which will stop the terminal content from moving. When focus returns to the rest of the page, the body is returned to regular overflow.

When this overflow transition happens, the page scrollbar appears and disappears on the right, which is a bit disconcerting as the terminal content will jump around. To prevent this, `body::-webkit-scrollbar` is added which hides the page scrollbar while maintaining functionality. This is up for debate - some users might find it handy to drag the scrollbar and may not want it hidden. Definitely looking for feedback here!

Many responsive adjustments are made as well.

Reference: https://github.com/kh90909/OakTerm/issues/4
