### PR TITLE
Move pollers into promise chain

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -5,6 +5,7 @@ $(function() {
   var claim_code = "";
   var claimed_devices = "";
   var current_device = "";
+  var pollers = [];
 
   var access_token = localStorage.getItem("access_token");
   var particle = new Particle();
@@ -26,6 +27,7 @@ $(function() {
 
   function do_login(){
     login()
+      .then(start_pollers)
       .then(get_devices)
       .then(update_devices)
       .then(get_devinfo)
@@ -221,17 +223,23 @@ $(function() {
       .then(update_devinfo);
   });
 
-  setInterval(function(){
-    console.log('Update device list timer');
-    get_devices()
-      .then(update_devices);
-    },device_list_refresh_interval*1000);
+  function start_pollers(){
+    return new Promise(function(){
+      if( pollers.update_devices) clearTimeout( pollers.update_devices);
+      pollers['update_devices'] = setInterval(function(){
+        console.log('Update device list timer');
+        get_devices()
+          .then(update_devices);
+        },device_list_refresh_interval*1000);
 
-  setInterval(function(){
-    console.log('Update device info timer');
-    get_devinfo()
-      .then(update_devinfo);
-    },device_info_refresh_interval*1000);
+      if( pollers.update_devinfo) clearTimeout( pollers.update_devinfo);
+      pollers['update_devinfo'] = setInterval(function(){
+        console.log('Update device info timer');
+        get_devinfo()
+          .then(update_devinfo);
+        },device_info_refresh_interval*1000);
+    });
+  }
 });
 
 function set_heights(){


### PR DESCRIPTION
The two `setInterval` pollers are now available within a promise, and are subsequently initiated in the `do_login()` promise chain. This ensures that polling only starts once authentication has passed.

When testing this initially the `update_devinfo` poller was doubling up, suggesting that the `setInterval` had been processed twice. To avoid this, a new `pollers[]` array was added, and the `start_pollers()` function checks to make sure each poller is only added once.

Reference: https://github.com/kh90909/OakTerm/issues/5
