### PR TITLE
Fixing device reselection, updating HTML render methods

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,3 +1,27 @@
+/* Terminal Content */
+.selected{
+  background-color: #1f8dd6;
+  color: white;
+}
+.text_stdin     { color: #808080; }
+.text_stdout    { color: #ffffff; }
+.text_stderr    { color: #d9534f; }
+.text_event     { color: #DCDC00; }
+.text_sentevent { color: #f0ad4e; }
+.text_variable  { color: #5bc0de; }
+.text_function  { color: #5cb85c; }
+
+.var-type-bool  { background-color:#0275d8; border-color: #0275d8; }
+.var-type-int   { background-color:#f0ad4e; border-color: #f0ad4e; }
+.var-type-string{ background-color:#449d44; border-color: #419641; }
+.var-type-double{ background-color:#d9534f; border-color: #d9534f; }
+
+.var-type-bool:hover  { background-color:#025aa5; border-color: #01549b; }
+.var-type-int:hover   { background-color:#ec971f; border-color: #eb9316; }
+.var-type-string:hover{ background-color:#449d44; border-color: #419641; }
+.var-type-double:hover{ background-color:#c9302c; border-color: #c12e2a; }
+
+
 /* Global styling */
 html{ font-size:14px; }
 body, html{ background: #252830; color:#fff; }
@@ -111,19 +135,6 @@ body::-webkit-scrollbar,
 .modal .form-control:focus{
   border-color:#373a3c;
 }
-
-/* Terminal Content */
-.selected{
-  background-color: #1f8dd6;
-  color: white;
-}
-.text_stdin     { color: #808080; }
-.text_stdout    { color: #ffffff; }
-.text_stderr    { color: #d9534f; }
-.text_event     { color: #DCDC00; }
-.text_sentevent { color: #f0ad4e; }
-.text_variable  { color: #5bc0de; }
-.text_function  { color: #5cb85c; }
 
 /* Sidebar and Controls */
 #show-sidebar{

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -131,6 +131,9 @@ body::-webkit-scrollbar,
   font-size:2rem;
   z-index: 1;
 }
+#devstatus .label{ display: none; }
+#devstatus[data-status="true"] .online{ display: inline;}
+#devstatus[data-status="false"] .offline{ display: inline;}
 
 /* Responsive */
 @media (max-width: 768px){

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -7,16 +7,9 @@ $(function() {
   var current_device = "";
   var pollers = [];
   var device_vars = {};
-  var device_vartypes = {};
   var settings = get_settings();
   var access_token = localStorage.getItem("access_token");
   var particle = new Particle();
-  var varTypeColors = {
-    bool: 'primary',
-    int: 'warning',
-    double: 'danger',
-    string: 'success'
-  };
 
   restore_settings();
   $('[data-toggle="tooltip"]').tooltip();
@@ -159,7 +152,7 @@ $(function() {
           var $var = $('<td>', {id: name, html: (typeof variable.value == 'undefined') ? '?' : variable.value.toString() });
           var $btn = $('<button>', {type: 'button', "class":"btn btn-sm", html: name})
             .addClass('btn-var-'+name)
-            .addClass('btn-'+varTypeColors[variable.type]);
+            .addClass('var-type-'+variable.type);
 
           $row
             .append( $('<td>').append($btn) )
@@ -197,10 +190,9 @@ $(function() {
 
     if((localVar.type == 'double') && (data.body.result == null)){
       result = 'NaN/Inf';
-    }
-
-    if(localVar.type == 'bool')
+    } else{
       result = data.body.result.toString();
+    }
 
     $("[id='"+data.body.name+"']").html(result);
   }
@@ -292,7 +284,9 @@ $(function() {
   $("#deviceIDs").on('change',function(){
     current_device=this.value;
     get_devinfo()
-      .then(update_devinfo);
+      .then(update_devinfo)
+      .then(subscribe_events)
+      .then(display_event);
   });
 
   function start_pollers(){

--- a/index.html
+++ b/index.html
@@ -88,7 +88,11 @@
       <div class="container-fluid">
         <div id="sidebar" class="col-md-3 fixed-sidebar" >
           <fieldset class="form-group">
-            <label for="deviceIDs">Device: </label> <span class="label label-danger" id="devstatus">offline</span>
+            <label for="deviceIDs">Device: </label>
+            <span id="devstatus" data-status="false">
+              <span class="label online label-success">online</span>
+              <span class="label offline label-danger">offline</span>
+            </span>
             <select id="deviceIDs" class="form-control">
               <option>--</option>
             </select>
@@ -108,7 +112,7 @@
           <fieldset class="form-group">
             <label for="funcs">Functions</label>
             <select id="funcs" class="form-control">
-              <option>None registered</option>
+              <option>--</option>
             </select>
           </fieldset>
         </div>


### PR DESCRIPTION
@kh90909 this contains some rework ideas and I would like your input!

The device "online/offline" label logic has been moved from JS into CSS to reduce JS complexity. Now the `#devstatus` div now toggles a data attribute, and a child label is shown corresponding to the `data.body.connected` property.

Variable table variables are now in buttons that vary color based on type.

Some of the HTML building/rendering has been converted to jQuery syntax to improve readability. This conversion also allows us to inject variables straight in to element attributes, like `$('<option>', {selected: (current_device == item.id)}` which results in `<option selected="selected">` with far less conditional wrapping. This particular sample is also the fix for https://github.com/kh90909/OakTerm/issues/26.

The `device_vars` variable has been restructured so that it contains more relevant data about a single common parent - instead of having a separate object for `device_vartypes`, it makes sense to group these things: `device_vartypes = { variable1: {type: 'int', value: 123}, variable2: {type: 'bool', value: false}}`. This means we can cut out a lot of the error checking around `update_variable()` and get right down to working with the data... but it creates some really interesting issues around updating these objects.

Variables are "detected" (added to `device_vars`) during the `update_devinfo()` call, but the variable values are discovered during `get_variables()` in a separate API call, so we have to merge and maintain this data model across a few states. Lines 148-154 of `app.js` handle adding/removing variables from `device_vars` according to the device query, and then the existing and/or new values for each variable are deep merged (jQuery `$.extend` instead of underscore) down onto the `device_vars`. 

I think that `device_vartypes` is now unused and can be removed.
