### PR TITLE
Adding sidebar device data, rename modal, current_device conversion

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -26,6 +26,7 @@
 html{ font-size:14px; }
 body, html{ background: #252830; color:#fff; }
 .align-right{ text-align: right; }
+.float-right{ float:right; }
 .center{ text-align: center; }
 
 /* Bootstrap Overrides */
@@ -78,6 +79,19 @@ table{ background-color: transparent;}
 table td, table th{color: #cfd2da; }
 .table td{ border-color: #434857; }
 .table thead th{ border-top:0px none; border-color: #434857; }
+table.compact th,
+table.compact td{
+  padding:.45rem;
+  font-size:.9rem;
+}
+.flex-input{ display: flex; }
+.flex-input select, .flex-input input{ flex: 1}
+.flex-input button{ margin-left:.5rem;}
+.form-control.compact{
+  height:auto;
+  padding:0 13px;
+  font-size:12px;
+}
 
 /* Access Control */
 #login{ display: none; padding-top:30px; }
@@ -136,15 +150,13 @@ table td, table th{color: #cfd2da; }
 }
 
 /* Sidebar and Controls */
-#sidebar .form-group{
-  margin-bottom:2em;
-}
 #show-sidebar{
   color:#fff;
   font-size:2rem;
   z-index: 1;
 }
-
+#sidebar table{ margin-bottom:2em;}
+.form-group.device-select{ margin-bottom:5px; }
 #devstatus .label{ display: none; }
 #devstatus[data-status="true"] .online{ display: inline;}
 #devstatus[data-status="false"] .offline{ display: inline;}
@@ -153,6 +165,7 @@ table td, table th{color: #cfd2da; }
 @media (max-width: 768px){
   .sm-center{ text-align: center; }
   .sm-align-right{ text-align: right; }
+  .sm-align-left{ text-align: left; }
 
   .fixed-sidebar{
     transform:translateX(-100%);
@@ -167,6 +180,7 @@ table td, table th{color: #cfd2da; }
 @media (max-width: 544px){
   .xs-center{ text-align: center; }
   .xs-align-right{ text-align: right; }
+  .xs-align-left{ text-align: left; }
   #show-sidebar{
     position: absolute;
     top:5px;

--- a/index.html
+++ b/index.html
@@ -87,27 +87,48 @@
 
       <div class="container-fluid">
         <div id="sidebar" class="col-md-3 fixed-sidebar">
-          <fieldset class="form-group">
+          <fieldset class="form-group device-select">
             <label for="deviceIDs"><h5>Device:</h5> </label>
             <span id="devstatus" data-status="false">
               <span class="label online label-success">online</span>
               <span class="label offline label-danger">offline</span>
             </span>
-            <select id="deviceIDs" class="form-control">
-              <option>--</option>
-            </select>
+
+            <div class="flex-input">
+              <select id="deviceIDs" class="form-control">
+                <option>--</option>
+              </select>
+              <button class="btn btn-sm btn-primary float-right" data-toggle="collapse" data-target="#device-details">
+              <i class="fa fa-angle-down"></i>
+            </button>
+            </div>
           </fieldset>
 
-          <label for="varstable"><h5>Variables</h5></label>
-          <table class="table" id="varstable">
-            <thead><tr>
-              <th>Name</th>
-              <th>Value</th>
-            </tr></thead>
-            <tbody id="varstbody">
-              <tr><td colspan="2" class="centered"><i>None exposed by firmware</i></td></tr>
-            </tbody>
-          </table>
+          <fieldset class="form-group">
+            <div class="collapse" id="device-details">
+              <table class="table compact" id="devtable">
+                <tfoot><tr><td></td><td class="align-right">
+                  <button class="btn btn-warning btn-sm" data-toggle="modal" data-target="#modal-rename-device">
+                    Rename <i class="fa fa-pencil"></i>
+                  </button>
+                </td></tr></tfoot>
+                <tbody></tbody>
+              </table>
+            </div>
+          </fieldset>
+
+          <fieldset class="form-group">
+            <label for="varstable"><h5>Variables</h5></label>
+            <table class="table" id="varstable">
+              <thead><tr>
+                <th>Name</th>
+                <th>Value</th>
+              </tr></thead>
+              <tbody id="varstbody">
+                <tr><td colspan="2" class="centered"><em>None exposed by firmware</em></td></tr>
+              </tbody>
+            </table>
+          </fieldset>
 
           <fieldset class="form-group">
             <label for="funcs"><h5>Functions</h5></label>
@@ -143,25 +164,28 @@
       </div>
 
       <footer id="footer" class="container-fluid">
-        <div class="col-md-8">
-          <input type="text" class="form-control" id="senddata" placeholder="Send Data">
+        <div class="col-md-10">
+          <div class="flex-input">
+            <input type="text" class="form-control" id="senddata" placeholder="Send Data">
+            <button id="send" type="submit" class="btn btn-success hidden-sm-down"><i class="fa fa-paper-plane"></i> Send Data</button>
+          </div>
         </div>
 
-        <div class="col-md-2 col-xs-6">
-          <button id="send" type="submit" class="btn btn-success"><i class="fa fa-paper-plane"></i> Send Data</button>
-        </div>
-
-
-        <div class="col-md-2 align-right">
-          <button class="btn btn-info"  data-toggle="modal" data-target="#settings-modal">
+        <div class="col-md-2 col-xs-6 align-right sm-align-left">
+          <button class="btn btn-info"  data-toggle="modal" data-target="#modal-settings">
             <i class="fa fa-cog"></i></button>
           <button class="btn btn-secondary" id="logout" data-toggle="tooltip" data-placement="top" title="Sign Out">
             <i class="fa fa-sign-out"></i></button>
         </div>
+
+        <div class="col-xs-6 hidden-md-up align-right">
+          <button id="send" type="submit" class="btn btn-success"><i class="fa fa-paper-plane"></i> Send Data</button>
+        </div>
+
       </footer><!-- #footer -->
     </div><!-- #terminal -->
 
-    <div class="modal fade" id="settings-modal">
+    <div class="modal fade" id="modal-settings">
       <div class="modal-dialog" role="document">
         <div class="modal-content">
           <div class="modal-header">
@@ -205,6 +229,30 @@
                       <span class="c-indicator"></span> Disabled
                     </label>
                   </div>
+                </div>
+              </div>
+            </form>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+          </div>
+        </div><!-- /.modal-content -->
+      </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
+
+    <div class="modal fade" id="modal-rename-device">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h4 class="modal-title">Rename Device: <span data-bind="deviceName"></span></h4>
+          </div>
+          <div class="modal-body">
+            <form id="rename-device">
+              <div class="form-group">
+                <label for="newname">New Name</label>
+                <div class="flex-input">
+                  <input type="text" class="form-control" placeholder="new device name" />
+                  <button id="rename_device" type="button" class="btn btn-danger">Rename Device</button>
                 </div>
               </div>
             </form>


### PR DESCRIPTION
Breaking change: `current_device` is now an object to help provide context to some parts of the init process.

Modal added for renaming devices - actual functionality not implemented yet though.

Added some device details to the sidebar, re-styled tables to match the Bootstrap v4 admin template. 
