### PR TITLE
Changing reboot button to dropdown

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -259,7 +259,13 @@ $(function() {
     });
   }
 
-  $("#reboot").click(function(){
+  $("#reboot-all").click(function(e){
+    e.preventDefault();
+    send_cmd("reboot");
+  });
+
+  $("#reboot-current").click(function(e){
+    e.preventDefault();
     send_cmd("reboot");
   });
 

--- a/index.html
+++ b/index.html
@@ -67,8 +67,17 @@
             <i class="fa fa-refresh"></i></button>
           <button class="btn btn-secondary" id="sendevent" data-toggle="tooltip" data-placement="bottom" title="Send Event">
             <i class="fa fa-paper-plane"></i></button>
-          <button class="btn btn-danger" id="reboot" data-toggle="tooltip" data-placement="bottom" title="Reboot">
-            <i class="fa fa-power-off"></i></button>
+
+          <div class="btn-group">
+            <button type="button" class="btn btn-danger dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <i class="fa fa-power-off"></i>
+            </button>
+            <div class="dropdown-menu">
+              <a class="dropdown-item" href="#" id="reboot-current">Reboot current device</a>
+              <a class="dropdown-item" href="#" id="reboot-all">Reboot all devices</a>
+            </div>
+          </div>
+
           <button class="btn btn-info" id="configmode" data-toggle="tooltip" data-placement="bottom" title="Config Mode">
             <i class="fa fa-cogs"></i></button>
           <button class="btn btn-warning" id="usermode" data-toggle="tooltip" data-placement="bottom" title="User Mode">


### PR DESCRIPTION
Adds a dropdown interface to the Reboot button and binds the reboot functions to each link in the dropdown. Rebooting a targeted device is not yet supported.

Reference: https://github.com/kh90909/OakTerm/issues/29
