### PR TITLE
Expandable sidebar sections for vars and funcs

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -46,6 +46,8 @@ body::-webkit-scrollbar,
   border-radius: 4px;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
 }
+.btn-primary-outline:focus,
+.btn-primary-outline:active{ background: transparent; }
 .form-control:focus {
   color: #252830;
   background-color: #fff;
@@ -155,12 +157,17 @@ table.compact td{
   font-size:2rem;
   z-index: 1;
 }
-#sidebar table{ margin-bottom:2em;}
+#sidebar .wrap{ margin:1rem 0 2em 0;}
+#sidebar .form-group{
+  border-top:2px solid #434857;
+  margin:.33rem 0;
+  padding:calc(.33rem + 2px) 0;
+}
 #devstatus .label{ display: none; }
 #devstatus[data-status="true"] .online{ display: inline;}
 #devstatus[data-status="false"] .offline{ display: inline;}
 .sidebar-category-header button{ width:31px; }
-.sidebar-category-header-element{ line-height: 1.55; cursor: pointer; }
+.sidebar-category-header-element{ line-height: 1.55; cursor: pointer; margin: 0;}
 
 
 /* Responsive */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -156,10 +156,30 @@ table.compact td{
   z-index: 1;
 }
 #sidebar table{ margin-bottom:2em;}
-.form-group.device-select{ margin-bottom:5px; }
 #devstatus .label{ display: none; }
 #devstatus[data-status="true"] .online{ display: inline;}
 #devstatus[data-status="false"] .offline{ display: inline;}
+
+.sidebar-category-header{
+    display: table;
+}
+
+.sidebar-category-header-element{
+    display: table-cell;
+    vertical-align: middle;
+}
+
+div.sidebar-category-header-element{
+    padding-left: 0.2em;
+}
+
+button.sidebar-category-header-element{
+    padding:1px;
+}
+
+.angle-button{
+    width:2em;
+}
 
 /* Responsive */
 @media (max-width: 768px){

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -159,27 +159,9 @@ table.compact td{
 #devstatus .label{ display: none; }
 #devstatus[data-status="true"] .online{ display: inline;}
 #devstatus[data-status="false"] .offline{ display: inline;}
+.sidebar-category-header button{ width:31px; }
+.sidebar-category-header-element{ line-height: 1.55; cursor: pointer; }
 
-.sidebar-category-header{
-    display: table;
-}
-
-.sidebar-category-header-element{
-    display: table-cell;
-    vertical-align: middle;
-}
-
-div.sidebar-category-header-element{
-    padding-left: 0.2em;
-}
-
-button.sidebar-category-header-element{
-    padding:1px;
-}
-
-.angle-button{
-    width:2em;
-}
 
 /* Responsive */
 @media (max-width: 768px){

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -337,7 +337,7 @@ $(function() {
   });
 
   function toggle_arrow(e){
-    $('[data-target="#'+e.target.id+'"] i').toggleClass('fa-angle-down fa-angle-right');
+    $('[data-target="#'+e.target.id+'"] i').toggleClass('fa-angle-up fa-angle-down');
   }
 
   function terminal_print(content){

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -329,15 +329,15 @@ $(function() {
 
   $('#settings input, #settings select').on('change', save_settings);
 
-  $('#device-details').on('hide.bs.collapse', toggle_arrow);
-  $('#device-details').on('show.bs.collapse', toggle_arrow);
+  $('#device-details,#var-details,#func-details').on('hide.bs.collapse', toggle_arrow);
+  $('#device-details,#var-details,#func-details').on('show.bs.collapse', toggle_arrow);
 
   $('#modal-rename-device').on('show.bs.modal', function (e) {
     $('#modal-rename-device [data-bind="deviceName"]').text(current_device.name);
   });
 
   function toggle_arrow(e){
-    $('[data-target="#'+e.target.id+'"] i').toggleClass('fa-angle-down fa-angle-up');
+    $('[data-target="#'+e.target.id+'"] i').toggleClass('fa-angle-down fa-angle-right');
   }
 
   function terminal_print(content){

--- a/index.html
+++ b/index.html
@@ -120,14 +120,16 @@
               </div>
             </div>
           <div class="collapse" id="device-details">
-            <table class="table compact" id="devtable">
-              <tfoot><tr><td></td><td class="align-right">
-                <button class="btn btn-warning btn-sm" data-toggle="modal" data-target="#modal-rename-device">
-                  Rename <i class="fa fa-pencil"></i>
-                </button>
-              </td></tr></tfoot>
-              <tbody></tbody>
-            </table>
+            <div class="wrap">
+              <table class="table compact" id="devtable">
+                <tfoot><tr><td></td><td class="align-right">
+                  <button class="btn btn-warning btn-sm" data-toggle="modal" data-target="#modal-rename-device">
+                    Rename <i class="fa fa-pencil"></i>
+                  </button>
+                </td></tr></tfoot>
+                <tbody></tbody>
+              </table>
+            </div>
           </div>
           </fieldset>
 
@@ -141,11 +143,13 @@
               </div>
             </div>
             <div class="collapse" id="var-details">
-              <table class="table compact" id="varstable">
-                <tbody id="varstbody">
-                  <tr><td colspan="2" class="centered"><em>None exposed by firmware</em></td></tr>
-                </tbody>
-              </table>
+              <div class="wrap">
+                <table class="table compact" id="varstable">
+                  <tbody id="varstbody">
+                    <tr><td colspan="2" class="centered"><em>None exposed by firmware</em></td></tr>
+                  </tbody>
+                </table>
+              </div>
             </div>
           </fieldset>
 
@@ -159,9 +163,11 @@
               </div>
             </div>
             <div class="collapse" id="func-details">
-            <select id="funcs" class="form-control">
-              <option>--</option>
-            </select>
+              <div class="wrap">
+                <select id="funcs" class="form-control">
+                  <option>--</option>
+                </select>
+              </div>
           </fieldset>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
 
       <div class="container-fluid">
         <div id="sidebar" class="col-md-3 fixed-sidebar">
-          <fieldset class="form-group device-select">
+          <fieldset class="form-group">
             <label for="deviceIDs"><h5>Device:</h5> </label>
             <span id="devstatus" data-status="false">
               <span class="label online label-success">online</span>
@@ -107,40 +107,58 @@
               <select id="deviceIDs" class="form-control">
                 <option>--</option>
               </select>
-              <button class="btn btn-sm btn-primary float-right" data-toggle="collapse" data-target="#device-details">
-              <i class="fa fa-angle-down"></i>
-            </button>
             </div>
           </fieldset>
 
           <fieldset class="form-group">
-            <div class="collapse" id="device-details">
-              <table class="table compact" id="devtable">
-                <tfoot><tr><td></td><td class="align-right">
-                  <button class="btn btn-warning btn-sm" data-toggle="modal" data-target="#modal-rename-device">
-                    Rename <i class="fa fa-pencil"></i>
-                  </button>
-                </td></tr></tfoot>
-                <tbody></tbody>
+            <div class="sidebar-category-header">
+              <button class="btn btn-sm btn-primary angle-button sidebar-category-header-element" data-toggle="collapse" data-target="#device-details">
+                <i class="fa fa-angle-right"></i>
+              </button>
+              <div class="h5 sidebar-category-header-element">
+                Device info
+              </div>
+            </div>
+          <div class="collapse" id="device-details">
+            <table class="table compact" id="devtable">
+              <tfoot><tr><td></td><td class="align-right">
+                <button class="btn btn-warning btn-sm" data-toggle="modal" data-target="#modal-rename-device">
+                  Rename <i class="fa fa-pencil"></i>
+                </button>
+              </td></tr></tfoot>
+              <tbody></tbody>
+            </table>
+          </div>
+          </fieldset>
+
+          <fieldset class="form-group">
+            <div class="sidebar-category-header">
+              <button class="btn btn-sm btn-primary angle-button sidebar-category-header-element" data-toggle="collapse" data-target="#var-details">
+                <i class="fa fa-angle-right"></i>
+              </button>
+              <div class="h5 sidebar-category-header-element">
+                Variables
+              </div>
+            </div>
+            <div class="collapse" id="var-details">
+              <table class="table compact" id="varstable">
+                <tbody id="varstbody">
+                  <tr><td colspan="2" class="centered"><em>None exposed by firmware</em></td></tr>
+                </tbody>
               </table>
             </div>
           </fieldset>
 
           <fieldset class="form-group">
-            <label for="varstable"><h5>Variables</h5></label>
-            <table class="table" id="varstable">
-              <thead><tr>
-                <th>Name</th>
-                <th>Value</th>
-              </tr></thead>
-              <tbody id="varstbody">
-                <tr><td colspan="2" class="centered"><em>None exposed by firmware</em></td></tr>
-              </tbody>
-            </table>
-          </fieldset>
-
-          <fieldset class="form-group">
-            <label for="funcs"><h5>Functions</h5></label>
+            <div class="sidebar-category-header">
+              <button class="btn btn-sm btn-primary angle-button sidebar-category-header-element" data-toggle="collapse" data-target="#func-details">
+                <i class="fa fa-angle-right"></i>
+              </button>
+              <div class="h5 sidebar-category-header-element">
+                Functions
+              </div>
+            </div>
+            <div class="collapse" id="func-details">
             <select id="funcs" class="form-control">
               <option>--</option>
             </select>

--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
           <fieldset class="form-group">
             <div class="sidebar-category-header">
               <button class="btn btn-sm btn-primary-outline float-right" data-toggle="collapse" data-target="#device-details">
-                <i class="fa fa-angle-right"></i>
+                <i class="fa fa-angle-down"></i>
               </button>
               <div class="h5 sidebar-category-header-element" data-toggle="collapse" data-target="#device-details">
                 Device info
@@ -136,7 +136,7 @@
           <fieldset class="form-group">
             <div class="sidebar-category-header">
               <button class="btn btn-sm btn-primary-outline float-right " data-toggle="collapse" data-target="#var-details">
-                <i class="fa fa-angle-right"></i>
+                <i class="fa fa-angle-down"></i>
               </button>
               <div class="h5 sidebar-category-header-element" data-toggle="collapse" data-target="#var-details">
                 Variables
@@ -156,7 +156,7 @@
           <fieldset class="form-group">
             <div class="sidebar-category-header">
               <button class="btn btn-sm btn-primary-outline float-right" data-toggle="collapse" data-target="#func-details">
-                <i class="fa fa-angle-right"></i>
+                <i class="fa fa-angle-down"></i>
               </button>
               <div class="h5 sidebar-category-header-element" data-toggle="collapse" data-target="#func-details">
                 Functions

--- a/index.html
+++ b/index.html
@@ -112,10 +112,10 @@
 
           <fieldset class="form-group">
             <div class="sidebar-category-header">
-              <button class="btn btn-sm btn-primary angle-button sidebar-category-header-element" data-toggle="collapse" data-target="#device-details">
+              <button class="btn btn-sm btn-primary-outline float-right" data-toggle="collapse" data-target="#device-details">
                 <i class="fa fa-angle-right"></i>
               </button>
-              <div class="h5 sidebar-category-header-element">
+              <div class="h5 sidebar-category-header-element" data-toggle="collapse" data-target="#device-details">
                 Device info
               </div>
             </div>
@@ -133,10 +133,10 @@
 
           <fieldset class="form-group">
             <div class="sidebar-category-header">
-              <button class="btn btn-sm btn-primary angle-button sidebar-category-header-element" data-toggle="collapse" data-target="#var-details">
+              <button class="btn btn-sm btn-primary-outline float-right " data-toggle="collapse" data-target="#var-details">
                 <i class="fa fa-angle-right"></i>
               </button>
-              <div class="h5 sidebar-category-header-element">
+              <div class="h5 sidebar-category-header-element" data-toggle="collapse" data-target="#var-details">
                 Variables
               </div>
             </div>
@@ -151,10 +151,10 @@
 
           <fieldset class="form-group">
             <div class="sidebar-category-header">
-              <button class="btn btn-sm btn-primary angle-button sidebar-category-header-element" data-toggle="collapse" data-target="#func-details">
+              <button class="btn btn-sm btn-primary-outline float-right" data-toggle="collapse" data-target="#func-details">
                 <i class="fa fa-angle-right"></i>
               </button>
-              <div class="h5 sidebar-category-header-element">
+              <div class="h5 sidebar-category-header-element" data-toggle="collapse" data-target="#func-details">
                 Functions
               </div>
             </div>


### PR DESCRIPTION
What do you think about tweaking your expandable sidebar sections like this to move the show/hide button to the start of the label? It fits in better with the section label that way.

I changed the table style for the variables to match the device details...the compact style works better. Maybe we should make the values the buttons instead of the names - it would match the device details better.

The html/css for the section header with the show/hide button feels a bit kludgy - feel free to improve it.

All the sections start out hidden at the moment, but I think it probably makes sense to have some shown at login...perhaps variables and functions.
