### PR TITLE
Implement sending of events

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -178,7 +178,15 @@ table.compact td{
 .sidebar-category-header-element{ line-height: 1.55; cursor: pointer; margin: 0;}
 .func-arg-label{ float: left; margin-right: 4px;}
 a.func { color: #cfd2da;}
-.hint-icon {color: #A0A0A0;}
+.hint-icon {
+    color: #A0A0A0;
+    margin-left: 5px;
+    vertical-align: middle;
+}
+
+label.btn {
+    margin-bottom: 0;
+}
 
 /* Responsive */
 @media (max-width: 768px){

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -178,6 +178,7 @@ table.compact td{
 .sidebar-category-header-element{ line-height: 1.55; cursor: pointer; margin: 0;}
 .func-arg-label{ float: left; margin-right: 4px;}
 a.func { color: #cfd2da;}
+.hint-icon {color: #A0A0A0;}
 
 /* Responsive */
 @media (max-width: 768px){

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -339,6 +339,38 @@ $(function() {
       .then(update_devinfo);
   });
 
+  $("#modal-send-event-button").click(function(){
+    var event={ name: $('#event-name').val(),
+                data: $('#event-data').val(),
+                isPrivate: $('#event-private').prop('checked'),
+                auth: access_token };
+
+    console.log('Sending event:', event);
+    particle.publishEvent(event)
+      .then(function(response) { return {event:event, response:response}; })
+      .catch(function(response) { return new Promise(function(resolve, reject){
+        reject({event:event, response:response});
+        });
+      })
+      .then(dump_sent_event)
+      .catch(dump_send_event_err);
+  });
+
+  function dump_sent_event(data) {
+    delete data.event['auth'];
+    var htmlstr='<div class="text_sentevent">Sent event: ' +
+                JSON.stringify(data.event) + '</div>';
+    terminal_print(htmlstr);
+  }
+
+  function dump_send_event_err(data) {
+    delete data.event['auth'];
+    var htmlstr='<div class="text_sentevent">Error sending event: ' +
+                JSON.stringify(data.event) + '. ' +
+                data.response.errorDescription.split(' - ')[1] + '</div>';
+    terminal_print(htmlstr);
+  }
+
   $(document).on('click', '#varstable [data-variable]', dump_variable);
 
   $("#deviceIDs").on('change',function(){
@@ -475,7 +507,6 @@ $(function() {
       }
     });
   }
-
 });
 
 function set_heights(){

--- a/index.html
+++ b/index.html
@@ -332,10 +332,16 @@
               </div>
               -->
               <div class="form-group row">
-                <label for="event-private" class="col-sm-2 form-control-label">Private</label>
-                <div class="col-sm-2">
-                  <input type="checkbox" id="event-private" checked />
-                  <span class="hint-icon" data-toggle="tooltip" data-trigger="click hover focus" data-placement="right" title="Public events are visible to everyone, private events to clients associated with your Particle.io account only. Note that devices subscribed to events using the MY_DEVICES option will not receive a public event sent from OakTerm (or any sender using the Cloud or ParticleJS APIs)."><i class="fa fa-question-circle"></i></span>
+                <div class="col-sm-offset-2 col-sm-4">
+                  <div class="btn-group" data-toggle="buttons">
+                    <label class="btn btn-secondary active">
+                      <input type="radio" name="event-private" id="event-private" autocomplete="off" checked> Private
+                    </label>
+                    <label class="btn btn-secondary">
+                      <input type="radio" name="event-private" autocomplete="off"> Public
+                    </label>
+                  </div>
+                  <span data-toggle="tooltip" data-trigger="click hover focus" data-placement="right" title="Public events are visible to everyone, private events to clients associated with your Particle.io account only. Note that devices subscribed to events using the MY_DEVICES option will not receive a public event sent from OakTerm (or any sender using the Cloud or ParticleJS APIs)."><i class="fa fa-question-circle hint-icon"></i></span>
                 </div>
               </div>
             </form>

--- a/index.html
+++ b/index.html
@@ -65,9 +65,11 @@
         <div class="col-md-4 col-sm-7 col-xs-12 sm-align-right xs-center">
           <button class="btn btn-success" id="refresh" data-toggle="tooltip" data-placement="bottom" title="Refresh">
             <i class="fa fa-refresh"></i></button>
-          <button class="btn btn-secondary" id="sendevent" data-toggle="tooltip" data-placement="bottom" title="Send Event">
-            <i class="fa fa-paper-plane"></i></button>
-
+          <span data-toggle="modal" data-target="#modal-send-event">
+            <button class="btn btn-secondary" id="sendevent" data-toggle="tooltip" data-placement="bottom" data-trigger="hover" title="Send Event">
+              <i class="fa fa-paper-plane"></i>
+            </button>
+          </span>
           <div class="btn-group">
             <button type="button" class="btn btn-danger dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               <i class="fa fa-power-off"></i>
@@ -295,6 +297,52 @@
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+          </div>
+        </div><!-- /.modal-content -->
+      </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
+
+    <div class="modal fade" id="modal-send-event">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h4 class="modal-title">Send Event</h4>
+          </div>
+          <div class="modal-body">
+            <form id="send-event" class="form-horizontal">
+              <div class="form-group row">
+                <label for="event-name" class="col-sm-2 form-control-label">Name</label>
+                <div class="col-sm-10">
+                  <input type="text" id="event-name" class="form-control" placeholder="oak/custom/myevent" autofocus />
+                </div>
+              </div>
+              <div class="form-group row">
+                <label for="event-data" class="col-sm-2 form-control-label">Data</label>
+                <div class="col-sm-10">
+                  <input type="text" id="event-data" class="form-control col-sm-9" placeholder="My Data" />
+                </div>
+              </div>
+              <!-- The ttl option is not yet supported by ParticleJS -->
+              <!--
+              <div class="form-group row">
+                <label for="event-ttl" class="col-sm-2 form-control-label">TTL</label>
+                <div class="col-sm-2">
+                  <input type="number" id="event-ttl" class="form-control col-sm-3" value="60" />
+                </div>
+              </div>
+              -->
+              <div class="form-group row">
+                <label for="event-private" class="col-sm-2 form-control-label">Private</label>
+                <div class="col-sm-2">
+                  <input type="checkbox" id="event-private" checked />
+                  <span class="hint-icon" data-toggle="tooltip" data-trigger="click hover focus" data-placement="right" title="Public events are visible to everyone, private events to clients associated with your Particle.io account only. Note that devices subscribed to events using the MY_DEVICES option will not receive a public event sent from OakTerm (or any sender using the Cloud or ParticleJS APIs)."><i class="fa fa-question-circle"></i></span>
+                </div>
+              </div>
+            </form>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn" data-dismiss="modal">Cancel</button>
+            <button type="button" id="modal-send-event-button" class="btn btn-primary btn-default" data-dismiss="modal">Send</button>
           </div>
         </div><!-- /.modal-content -->
       </div><!-- /.modal-dialog -->


### PR DESCRIPTION
Clicking the send event button will bring up a modal where the user can
enter the event name, data and private/public flag. The event is then
sent via ParticleJS and success/failure dumped to the terminal.

Had to change the tooltip data-trigger attribute on the send event
button from the default of 'hover focus' to just 'hover'. Otherwise, the
tooltip would stay open until the modal was dismissed. Not sure what
impact this will have on mobile, may need to find a different
workaround.

The private/public checkbox is not aligning with it's label or the
tooltip question mark icon. Needs fixing.
