### PR TITLE
Implement file upload to stdin

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -72,14 +72,10 @@ body::-webkit-scrollbar,
   overflow-y:scroll;
   z-index: 1;
 }
-.file-custom{
-  background-color: #434857;
-  border: 1px solid #434857;
-  color: #ffffff;
+.file-input-hidden [type="file"]{
+  display: none;
 }
-.file-custom::after{
-  content: "Upload File..."
-}
+.file-input-hidden{ margin:0;}
 .navbar label{ margin:0;}
 .centered{
   text-align: center;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -356,6 +356,10 @@ $(function() {
       .catch(dump_send_event_err);
   });
 
+  $('.file-input-hidden > button').on('click', function(){
+    $(this).parent().find('[type="file"]').click();
+  });
+
   function dump_sent_event(data) {
     delete data.event['auth'];
     var htmlstr='<div class="text_sentevent">Sent event: ' +

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -404,6 +404,51 @@ $(function() {
     $('#file-input').click();
   });
 
+  $('#file-input').on('change',send_file);
+
+  function send_file(e){
+    console.log('send_file(e): e:',e);
+    if(e.target.files && e.target.files[0]){
+      var file = e.target.files[0];
+      var offset = 0;
+      var slice_len = 255;
+
+      // Disable user "Send Data" button so that it's not possible to send
+      // in the middle of the file upload
+      $("#send").addClass('disabled');
+      slice_reader();
+
+      function slice_reader(){
+        var reader = new FileReader();
+        var slice = file.slice(offset,offset+slice_len);
+
+        reader.onload = read_handler;
+        reader.onerror = error_handler;
+        reader.readAsBinaryString(slice);
+      };
+
+      function read_handler(e){
+        send_data(e.target.result);
+        offset+=slice_len;
+        if(offset >= file.size){
+          reset_ui();
+          return;
+        }
+        setTimeout(slice_reader,1000);
+      }
+
+      function error_handler(e){
+          console.log('Error reading file: ' + e.target.error);
+          reset_ui();
+      }
+
+      function reset_ui(){
+          $('#file-input').val(null);
+          $("#send").removeClass('disabled');
+      }
+    }
+  }
+
   $('#settings input, #settings select').on('change', save_settings);
 
   $('#device-details,#var-details,#func-details').on('hide.bs.collapse', toggle_arrow);

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
           <h1>OakTerm</h1>
         </div>
 
-        <div class="col-md-4 col-sm-7 col-xs-12 sm-align-right xs-center">
+        <div class="col-md-5 col-sm-7 col-xs-12 sm-align-right xs-center">
           <button class="btn btn-success" id="refresh" data-toggle="tooltip" data-placement="bottom" title="Refresh">
             <i class="fa fa-refresh"></i></button>
           <span data-toggle="modal" data-target="#modal-send-event">
@@ -72,7 +72,7 @@
           </span>
           <div class="btn-group">
             <button type="button" class="btn btn-danger dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              <i class="fa fa-power-off"></i>
+              <i class="fa fa-power-off" data-toggle="tooltip" data-placement="bottom" title="Reboot"></i>
             </button>
             <div class="dropdown-menu">
               <a class="dropdown-item" href="#" id="reboot-current">Reboot current device</a>
@@ -85,13 +85,13 @@
           <button class="btn btn-warning" id="usermode" data-toggle="tooltip" data-placement="bottom" title="User Mode">
             <i class="fa fa-user-secret"></i></button>
           <button class="btn btn-default hidden-md-up" id="file-btn" data-toggle="tooltip" data-placement="bottom" title="Upload File">
-            <i class="fa fa-upload"></i></button>
+            <i class="fa fa-cloud-upload"></i></button>
         </div>
 
-        <form class="form-inline col-md-3 hidden-sm-down">
-          <label class="file">
+        <form class="form-inline col-lg-4 col-md-3 hidden-sm-down align-right">
+          <label class="file file-input-hidden">
             <input type="file" id="file-input">
-            <span class="file-custom"></span>
+            <button type="button" class="btn btn-secondary">Upload File <i class="fa fa-cloud-upload"></i></button>
           </label>
         </form>
       </nav>


### PR DESCRIPTION
The file is split into 255 byte chunks which are sent one every second
to the Oak's stdin to avoid overloading the rx buffer or hitting the
Particle Cloud event frequency limit. The "Send Data" button is disabled
during the upload so that the user cannot interrupt the data stream.

We might consider adding a progress bar to communicate the upload
status, but I'm not sure if typical uploads will be big enough to
warrant this.

Right now, the text input field is superfluous as a path cannot be
entered with the keyboard and it must be cleared after upload, otherwise
the on-change event will not allow sending the same file twice. Perhaps
we should omit or hide the text input and keep the button only?
