### PR TITLE
Show hide individual content classes in terminal (stdin, stdour, stderr, events, variables, etc.)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -3,6 +3,9 @@
   background-color: #1f8dd6;
   color: white;
 }
+
+.timestamp { color: #848484; }
+
 .text_stdin     { color: #808080; }
 .text_stdout    { color: #ffffff; }
 .text_stderr    { color: #d9534f; }
@@ -11,11 +14,30 @@
 .text_variable  { color: #5bc0de; }
 .text_function  { color: #5cb85c; }
 .text_devadm { color: #a0a0ff; }
-.text_timestamp { color: #848484; }
-.text_indent {
+
+[class^="text_"] {
     text-indent: -11ch;
     padding-left: 11ch;
 }
+
+.hide_timestamp  .timestamp,
+.hide_stdin .text_stdin,
+.hide_stdout .text_stdout,
+.hide_stderr .text_stderr,
+.hide_event .text_event,
+.hide_sentevent .text_sentevent,
+.hide_variable .text_variable,
+.hide_function .text_function,
+.hide_devadm .text_devadm { display: none; }
+
+.hide_timestamp [class^="text_"] {
+    text-indent: 0ch;
+    padding-left: 0ch;
+}
+
+.hide_timestamp .text_stdout { display: inline; }
+
+
 .popover-content{ color: #000000 !important; }
 .popover-title{ display: none; }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -10,6 +10,12 @@
 .text_sentevent { color: #f0ad4e; }
 .text_variable  { color: #5bc0de; }
 .text_function  { color: #5cb85c; }
+.text_devadm { color: #a0a0ff; }
+.text_timestamp { color: #848484; }
+.text_indent {
+    text-indent: -11ch;
+    padding-left: 11ch;
+}
 .popover-content{ color: #000000 !important; }
 .popover-title{ display: none; }
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -288,40 +288,25 @@ $(function() {
     activeStream.on('event', function(event) {
 
       var event_class="";
+      var prestr="";
       switch(event.name){
         case 'oak/devices/stderr': // Typo in OakSystem.ino
         case 'oak/device/stderr':
-          if($("#content").html().endsWith('<br>')){
-            prestr='';
-          }
-          else{
-            prestr='';
-          }
-          poststr='';
           event_class='text_stderr';
           break;
         case 'oak/device/stdout':
-          prestr='';
-          poststr='';
           event_class='text_stdout';
           break;
         default:
           event_class='text_event';
-          if($("#content").html().endsWith('<br>')){
-            prestr='';
-          }
-          else{
-            prestr='';
-          }
-          prestr=prestr+'Event: '+ event.name + ' - ';
-          poststr='';
+          prestr='Event: '+ event.name + ' - ';
           if(event.data == null){
             event.data='<no data>';
           }
       }
       eventTime = format_time_span(event.published_at);
       htmlstr=(event.data + '').replace(/([^>\r\n]?)(\r\n|\n\r|\r|\n)/g, '$1<br>$2');
-      htmlstr='<div class="'+event_class+'">'+eventTime+prestr+htmlstr+poststr+'</div>';
+      htmlstr='<div class="'+event_class+'">'+eventTime+prestr+htmlstr+'</div>';
       terminal_print(htmlstr);
     });
   }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -304,12 +304,12 @@ $(function() {
         case 'oak/devices/stderr': // Typo in OakSystem.ino
         case 'oak/device/stderr':
           if($("#content").html().endsWith('<br>')){
-            prestr='<br>';
+            prestr='';
           }
           else{
             prestr='';
           }
-          poststr='<br>';
+          poststr='';
           event_class='text_stderr text_indent';
           break;
         case 'oak/device/stdout':
@@ -321,13 +321,13 @@ $(function() {
         default:
           event_class='text_event text_indent';
           if($("#content").html().endsWith('<br>')){
-            prestr='<br>';
+            prestr='';
           }
           else{
             prestr='';
           }
           prestr=prestr+'Event: '+ event.name + ' - ';
-          poststr='<br>';
+          poststr='';
           if(event.data == null){
             event.data='<no data>';
           }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -522,7 +522,7 @@ $(function() {
 
   function set_term_indent(override){
     var tlen=$(format_time_span()).html().length;
-    if(override){ tlen=override; }
+    if(typeof(override)!='undefined'){ tlen=override; }
     term_text_classes['.text_indent'].style.textIndent = -tlen+"ch";
     term_text_classes['.text_indent'].style.paddingLeft = tlen+"ch";
   }
@@ -536,22 +536,30 @@ $(function() {
 
   function show_hide_term_cat(cat){
     var cls='.text_'+cat;
+    var show_timestamp;
+    _.each(settings,function(item,idx){
+      if(item.name == 'show-timestamp') {
+        show_timestamp=item.value;
+      }
+    });
 
     if($('#show-'+cat+'-on').prop('checked')){
       console.log('Showing class',cls);
-      if(cat == 'timestamp'){
-        set_term_indent();
-      }
-      if(cat == 'timestamp' || (cat == 'stdout' && settings['show-timestamp'] == 'false')){
+      if(cat == 'timestamp' || (cat == 'stdout' && show_timestamp == 'false')){
         term_text_classes[cls].style.display = "inline";
       } else {
         term_text_classes[cls].style.display = "block";
+      }
+      if(cat == 'timestamp'){
+        set_term_indent();
+        term_text_classes['.text_stdout'].style.display = "block";
       }
     } else {
       console.log('Hiding class',cls);
       term_text_classes[cls].style.display = "none";
       if(cat == 'timestamp') {
         set_term_indent(0);
+        term_text_classes['.text_stdout'].style.display = "inline";
       }
     }
   }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -329,7 +329,10 @@ $(function() {
   });
 
   $("#send").click(function(){
-    send_data($("#senddata").val());
+    var data=$("#senddata").val()
+    var htmlstr='<div class="text_stdin">' + data + '</div>';
+    send_data(data);
+    terminal_print(htmlstr);
   });
 
   $("#logout").click(function(){

--- a/index.html
+++ b/index.html
@@ -293,6 +293,126 @@
                   </div>
                 </div>
               </div>
+
+              <div class="form-group row">
+                <label class="col-sm-3 form-control-label">Show/Hide</label>
+                <div class="col-sm-4">
+                  <div class="btn-group" data-toggle="buttons">
+                    <label for="show-stdin-on" class="btn btn-sm btn-secondary active">
+                      <input type="radio" id="show-stdin-on" name="show-stdin" autocomplete="off" value="true" checked> On
+                    </label>
+                    <label for="show-stdin-off" class="btn btn-sm btn-secondary">
+                      <input type="radio" id="show-stdin-off" name="show-stdin" autocomplete="off" value="false"> Off
+                    </label>
+                  </div>
+                  <label for="show-stdin" class="form-control-sm form-control-label">stdin</label>
+                </div>
+
+                <div class="col-sm-5">
+                  <div class="btn-group" data-toggle="buttons">
+                    <label for="show-function-on" class="btn btn-sm btn-secondary active">
+                      <input type="radio" id="show-function-on" name="show-function" autocomplete="off" value="true" checked> On
+                    </label>
+                    <label for="show-function-off" class="btn btn-sm btn-secondary">
+                      <input type="radio" id="show-function-off" name="show-function" autocomplete="off" value="false"> Off
+                    </label>
+                  </div>
+                  <label for="show-function" class="form-control-sm form-control-label">Functions</label>
+                </div>
+              </div>
+
+              <div class="form-group row">
+                <div class="col-sm-offset-3 col-sm-4">
+                  <div class="btn-group" data-toggle="buttons">
+                    <label for="show-stdout-on" class="btn btn-sm btn-secondary active">
+                      <input type="radio" id="show-stdout-on" name="show-stdout" autocomplete="off" value="true" checked> On
+                    </label>
+                    <label for="show-stdout-off" class="btn btn-sm btn-secondary">
+                      <input type="radio" id="show-stdout-off" name="show-stdout" autocomplete="off" value="false"> Off
+                    </label>
+                  </div>
+                  <label for="show-stdout" class="form-control-sm form-control-label">stdout</label>
+                </div>
+
+                <div class="col-sm-5">
+                  <div class="btn-group" data-toggle="buttons">
+                    <label for="show-event-on" class="btn btn-sm btn-secondary active">
+                      <input type="radio" id="show-event-on" name="show-event" autocomplete="off" value="true" checked> On
+                    </label>
+                    <label for="show-event-off" class="btn btn-sm btn-secondary">
+                      <input type="radio" id="show-event-off" name="show-event" autocomplete="off" value="false"> Off
+                    </label>
+                  </div>
+                  <label for="show-event" class="form-control-sm form-control-label">Received events</label>
+                </div>
+              </div>
+
+              <div class="form-group row">
+                <div class="col-sm-offset-3 col-sm-4">
+                  <div class="btn-group" data-toggle="buttons">
+                    <label for="show-stderr-on" class="btn btn-sm btn-secondary active">
+                      <input type="radio" id="show-stderr-on" name="show-stderr" autocomplete="off" value="true" checked> On
+                    </label>
+                    <label for="show-stderr-off" class="btn btn-sm btn-secondary">
+                      <input type="radio" id="show-stderr-off" name="show-stderr" autocomplete="off" value="false"> Off
+                    </label>
+                  </div>
+                  <label for="show-stderr" class="form-control-sm form-control-label">stderr</label>
+                </div>
+
+                <div class="col-sm-5">
+                  <div class="btn-group" data-toggle="buttons">
+                    <label for="show-sentevent-on" class="btn btn-sm btn-secondary active">
+                      <input type="radio" id="show-sentevent-on" name="show-sentevent" autocomplete="off" value="true" checked> On
+                    </label>
+                    <label for="show-sentevent-off" class="btn btn-sm btn-secondary">
+                      <input type="radio" id="show-sentevent-off" name="show-sentevent" autocomplete="off" value="false"> Off
+                    </label>
+                  </div>
+                  <label for="show-sentevent" class="form-control-sm form-control-label">Sent events</label>
+                </div>
+              </div>
+
+              <div class="form-group row">
+                <div class="col-sm-offset-3 col-sm-4">
+                  <div class="btn-group" data-toggle="buttons">
+                    <label for="show-variable-on" class="btn btn-sm btn-secondary active">
+                      <input type="radio" id="show-variable-on" name="show-variable" autocomplete="off" value="true" checked> On
+                    </label>
+                    <label for="show-variable-off" class="btn btn-sm btn-secondary">
+                      <input type="radio" id="show-variable-off" name="show-variable" autocomplete="off" value="false"> Off
+                    </label>
+                  </div>
+                  <label for="show-variable" class="form-control-sm form-control-label">Variables</label>
+                </div>
+
+                <div class="col-sm-5">
+                  <div class="btn-group" data-toggle="buttons">
+                    <label for="show-timestamp-on" class="btn btn-sm btn-secondary active">
+                      <input type="radio" id="show-timestamp-on" name="show-timestamp" autocomplete="off" value="true" checked> On
+                    </label>
+                    <label for="show-timestamp-off" class="btn btn-sm btn-secondary">
+                      <input type="radio" for="show-timestamp-off" name="show-timestamp" autocomplete="off" value="false"> Off
+                    </label>
+                  </div>
+                  <label for="show-timestamp" class="form-control-sm form-control-label">Timestamps</label>
+                </div>
+              </div>
+
+              <div class="form-group row">
+                <div class="col-sm-offset-3 col-sm-5">
+                  <div class="btn-group" data-toggle="buttons">
+                    <label for="show-devadm-on" class="btn btn-sm btn-secondary active">
+                      <input type="radio" id="show-devadm-on" name="show-devadm" autocomplete="off" value="true" checked> On
+                    </label>
+                    <label for="show-devadm-off" class="btn btn-sm btn-secondary">
+                      <input type="radio" id="show-devadm-off" name="show-devadm" autocomplete="off" value="false"> Off
+                    </label>
+                  </div>
+                  <label for="show-devadm" class="form-control-sm form-control-label">Device admin</label>
+                </div>
+              </div>
+
             </form>
           </div>
           <div class="modal-footer">


### PR DESCRIPTION
Should resolve #15 and resolve #50.

---

This enables each class of data printed to the terminal (stdin, stdout,
stderr, functions, variables, received events and sent events) to be
shown or hidden independently. This is achieved for current and future
elements by modifying the display property of the corresponding CSS
classes. In addition, stdout data is displayed as a span so that
newlines sent by the Oak are honored, yet non-stdout information is
always displayed on its own line. This show/hide behavior is controlled
by toggles added to the settings modal, and these settings are saved to
localStorage like the others.

Timestamps are also implemented based on @emcniece's commit
emcniece/OakTerm@7f029ff. Again, CSS is modified to create a hanging
indent when timestamps are enabled so that lines wrap tidily. Also,
stdout data is switched to `display: 'block'` since honoring newlines
doesn't make sense with timestamps enabled.

Also adds a color class for the device rename and change events.
