### PR TITLE
Implement user settings functionality

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -53,15 +53,16 @@
 
 
 /* Global styling */
-html{ font-size:14px; }
+html{ font-size:14px; overflow: scroll !important;}
 body, html{ background: #252830; color:#fff; }
 .align-right{ text-align: right; }
 .float-right{ float:right; }
 .center{ text-align: center; }
 
 /* Bootstrap Overrides */
-body::-webkit-scrollbar,
-.fixed-sidebar::-webkit-scrollbar{ display: none }
+html.no-scroll-bars{ overflow: auto !important;}
+html.no-scroll-bars body::-webkit-scrollbar,
+html.no-scroll-bars .fixed-sidebar::-webkit-scrollbar{ display: none }
 .form-control:not(.form-control-func-arg) {
   display: block;
   width: 100%;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -53,14 +53,33 @@
 
 
 /* Global styling */
-html{ font-size:14px; overflow: scroll !important;}
+html{ font-size:14px; overflow-y: scroll !important;}
 body, html{ background: #252830; color:#fff; }
 .align-right{ text-align: right; }
 .float-right{ float:right; }
 .center{ text-align: center; }
+::-webkit-scrollbar {
+    width: 12px;
+}
+/* Track */
+::-webkit-scrollbar-track {
+    -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
+    -webkit-border-radius: 3px;
+    border-radius: 3px;
+}
+/* Handle */
+::-webkit-scrollbar-thumb {
+    -webkit-border-radius: 3px;
+    border-radius: 3px;
+    background: rgba(67,72,87,0.8);
+    -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.5);
+}
+::-webkit-scrollbar-thumb:window-inactive {
+  background: rgba(67,72,87,0.4);
+}
 
 /* Bootstrap Overrides */
-html.no-scroll-bars{ overflow: auto !important;}
+html.no-scroll-bars{ overflow-y: auto !important;}
 html.no-scroll-bars body::-webkit-scrollbar,
 html.no-scroll-bars .fixed-sidebar::-webkit-scrollbar{ display: none }
 .form-control:not(.form-control-func-arg) {
@@ -97,7 +116,7 @@ html.no-scroll-bars .fixed-sidebar::-webkit-scrollbar{ display: none }
   padding-top:70px;
   padding-bottom:70px;
   height:100%;
-  overflow-y:scroll;
+  overflow-y:auto;
   z-index: 1;
 }
 .file-input-hidden [type="file"]{

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -82,6 +82,9 @@ body, html{ background: #252830; color:#fff; }
 html.no-scroll-bars{ overflow-y: auto !important;}
 html.no-scroll-bars body::-webkit-scrollbar,
 html.no-scroll-bars .fixed-sidebar::-webkit-scrollbar{ display: none }
+body.modal-open { overflow: hidden!important; }
+body.modal-open::-webkit-scrollbar{ display: none }
+
 .form-control:not(.form-control-func-arg) {
   display: block;
   width: 100%;
@@ -95,7 +98,7 @@ html.no-scroll-bars .fixed-sidebar::-webkit-scrollbar{ display: none }
   border-radius: 4px;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
 }
-
+.collapsing{ clear:both; }
 .form-control-func-arg {
   color: #ffffff;
   background-color: #434857;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -651,7 +651,10 @@ $(function() {
   function get_setting(name){
     var val = settings[name];
     if(val === 'true') val = true;
-    if(val === 'false') val = false;
+    else if(val === 'false') val = false;
+    else if(val === '\\r\\n') val = '\r\n';
+    else if(val === '\\n') val = '\n';
+    else if(val === '\\r') val = '\r';
     return val;
   }
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -617,7 +617,7 @@ $(function() {
     var new_settings;
     var saved_settings = localStorage.getItem("settings");
     var defaults = {
-      "autoscroll": "pageBtm",
+      "autoscroll": "onEvent",
       "lineends": "\\r\\n",
       "scrollbars": "false",
       "show-devadm": "true",

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -548,12 +548,12 @@ $(function() {
 
     switch(get_setting('autoscroll')){
       case 'pageBtm':
-        if((window.innerHeight + window.scrollY) >= (document.body.offsetHeight-50)) {
-          $("html, body").animate({ scrollTop: $(document).height() }, 1000);
+        if((window.innerHeight + window.scrollY) >= (document.body.offsetHeight-30)) {
+          $("html, body").animate({ scrollTop: $(document).height() }, 250);
         }
         break;
       case 'onEvent':
-        $("html, body").animate({ scrollTop: $(document).height() }, 1000);
+        $("html, body").animate({ scrollTop: $(document).height() }, 250);
         break;
     }
   }
@@ -608,7 +608,7 @@ $(function() {
   }
 
   function save_settings(){
-    settings = $('#settings').serializeArray();
+    settings = _.object(_.map($('#settings').serializeArray(), _.values));
     localStorage.setItem("settings", JSON.stringify(settings));
     console.log( 'Saved settings:', settings);
   }
@@ -616,22 +616,21 @@ $(function() {
   function get_settings(){
     var new_settings;
     var saved_settings = localStorage.getItem("settings");
-    var defaults = [
-      {"name":"autoscroll","value":"onEvent"},
-      {"name":"lineends","value":"\\r\\n"},
-      {"name":"subenter","value":"true"},
-      {"name":"show-stdin","value":"true"},
-      {"name":"show-stdout","value":"true"},
-      {"name":"show-stderr","value":"true"},
-      {"name":"show-event","value":"true"},
-      {"name":"show-sentevent","value":"true"},
-      {"name":"show-variable","value":"true"},
-      {"name":"show-function","value":"true"},
-      {"name":"show-devadm","value":"true"},
-      {"name":"show-timestamp","value":"true"},
-      {"name":"echo","value":"true"},
-      {"name":"scrollbars","value":"false"}
-    ];
+    var defaults = {
+      "autoscroll": "pageBtm",
+      "lineends": "\\r\\n",
+      "scrollbars": "false",
+      "show-devadm": "true",
+      "show-event": "true",
+      "show-function": "true",
+      "show-sentevent": "true",
+      "show-stderr": "true",
+      "show-stdin": "true",
+      "show-stdout": "true",
+      "show-timestamp": "true",
+      "show-variable": "true",
+      "subenter": "true"
+    };
 
     if(saved_settings){
       try{
@@ -650,7 +649,7 @@ $(function() {
   }
 
   function get_setting(name){
-    var val = _.findWhere(settings, {name: name}).value;
+    var val = settings[name];
     if(val === 'true') val = true;
     if(val === 'false') val = false;
     return val;
@@ -667,26 +666,25 @@ $(function() {
     console.log('restoring settings:', settings);
 
     // User settings modal and content show/hide settings
-    _.each(settings, function(item){
-      var $item = $('[name="'+item.name+'"]');
+    _.each(settings, function(value, key){
+      var $item = $('[name="'+key+'"]');
       if($item.attr('type') == 'radio'){
         $item.each(function(){
-          $(this).prop('checked', $(this).val() == item.value);
+          $(this).prop('checked', $(this).val() == value);
           if($(this).parent().hasClass('btn')){
-            $(this).parent().toggleClass('active', $(this).val() == item.value);
+            $(this).parent().toggleClass('active', $(this).val() == value);
           }
         });
       } else{
-        $item.val(item.value);
+        $item.val(value);
       }
 
-      if ( item.name.slice(0,5) == 'show-' ) {
-        var item_class = 'hide_' + item.name.slice(5);
-        $('#content').toggleClass(item_class, item.value == 'false')
-        //console.log('restore_settings(): Turning', item.name.slice(5), item.value == 'true' ? 'on' : 'off');
+      if ( key.slice(0,5) == 'show-' ) {
+        var item_class = 'hide_' + key.slice(5);
+        $('#content').toggleClass(item_class, value == 'false')
       }
 
-      if(( item.name == 'scrollbars') && item.value == 'true'){
+      if(( key == 'scrollbars') && value === 'true'){
         $('html').removeClass('no-scroll-bars');
       }
     });

--- a/index.html
+++ b/index.html
@@ -165,37 +165,39 @@
               </div>
             </div>
             <div class="collapse" id="func-details">
-              <table class="table table-compact" id="funcstable">
-                <tbody id="funcstbody">
-                  <tr id="row-nofuncs">
-                    <td class="centered">
-                      <i>None exposed by firmware</i>
-                    </td>
-                  </tr>
-                  <script id="func-template" type="text/html">
-                    <td>
-                      <div>
-                        <a role="button" class="func" id="{{param1}}-row" data-target="[id='func-{{param1}}']" data-toggle="collapse">
-                          int {{param1}}(String arg);
-                        </a>
-                      </div>
-                      <div id="func-{{param1}}" class="collapse">
-                        <label for="arg-{{param1}}" class="func-arg-label">
-                          &#9495;&nbsp;arg
-                        </label>
-                        <div class="input-group input-group-sm">
-                          <input type="text" id="arg-{{param1}}" class=" form-control form-control-func-arg">
-                          <span class="input-group-btn">
-                            <button id="btn-{{param1}}" type="button" class="btn btn-primary">
-                              Call
-                            </button>
-                          </span>
+              <div class="wrap">
+                <table class="table table-compact" id="funcstable">
+                  <tbody id="funcstbody">
+                    <tr id="row-nofuncs">
+                      <td class="centered">
+                        <i>None exposed by firmware</i>
+                      </td>
+                    </tr>
+                    <script id="func-template" type="text/html">
+                      <td>
+                        <div>
+                          <a role="button" class="func" id="{{param1}}-row" data-target="[id='func-{{param1}}']" data-toggle="collapse">
+                            int {{param1}}(String arg);
+                          </a>
                         </div>
-                      </div>
-                    </td>
-                  </script>
-                </tbody>
-              </table>
+                        <div id="func-{{param1}}" class="collapse">
+                          <label for="arg-{{param1}}" class="func-arg-label">
+                            &#9495;&nbsp;arg
+                          </label>
+                          <div class="input-group input-group-sm">
+                            <input type="text" id="arg-{{param1}}" class=" form-control form-control-func-arg">
+                            <span class="input-group-btn">
+                              <button id="btn-{{param1}}" type="button" class="btn btn-primary">
+                                Call
+                              </button>
+                            </span>
+                          </div>
+                        </div>
+                      </td>
+                    </script>
+                  </tbody>
+                </table>
+              </div>
             </div>
           </fieldset>
         </div>
@@ -275,7 +277,7 @@
                 <label for="lineends" class="col-sm-3 form-control-label">Line Endings</label>
                 <div class="col-sm-9">
                   <select name="lineends" id="lineends" class="form-control">
-                    <option value="\r" selected>\r</option>
+                    <option value="\r">\r</option>
                     <option value="\n">\n</option>
                     <option value="\r\n">\r\n</option>
                     <option value="false">none</option>
@@ -292,6 +294,20 @@
                     </label>
                     <label class="btn btn-secondary">
                       <input type="radio" name="subenter" id="subenter-off" value="false"> Disabled
+                    </label>
+                  </div>
+                </div>
+              </div>
+
+              <div class="form-group row">
+                <label for="scrollbars" class="col-sm-3 form-control-label">Visible Scroll Bars</label>
+                <div class="col-sm-9">
+                  <div class="btn-group" data-toggle="buttons">
+                    <label for="scrollbars-on" class="btn btn-secondary">
+                      <input type="radio" name="scrollbars" id="scrollbars-on" value="true"> Enabled
+                    </label>
+                    <label for="scrollbars-off" class="btn btn-secondary active">
+                      <input type="radio" name="scrollbars" id="scrollbars-off" value="false" checked> Disabled
                     </label>
                   </div>
                 </div>
@@ -395,7 +411,7 @@
                       <input type="radio" id="show-timestamp-on" name="show-timestamp" autocomplete="off" value="true" checked> On
                     </label>
                     <label for="show-timestamp-off" class="btn btn-sm btn-secondary">
-                      <input type="radio" for="show-timestamp-off" name="show-timestamp" autocomplete="off" value="false"> Off
+                      <input type="radio" id="show-timestamp-off" name="show-timestamp" autocomplete="off" value="false"> Off
                     </label>
                   </div>
                   <label for="show-timestamp" class="form-control-sm form-control-label">Timestamps</label>
@@ -413,19 +429,6 @@
                     </label>
                   </div>
                   <label for="show-devadm" class="form-control-sm form-control-label">Device admin</label>
-                </div>
-              </div>
-              <div class="form-group row">
-                <label for="scrollbars" class="col-sm-3 form-control-label">Visible Scroll Bars</label>
-                <div class="col-sm-9">
-                  <div class="btn-group" data-toggle="buttons">
-                    <label for="scrollbars-on" class="btn btn-secondary">
-                      <input type="radio" name="scrollbars" id="scrollbars-on" value="true"> Enabled
-                    </label>
-                    <label for="scrollbars-off" class="btn btn-secondary">
-                      <input type="radio" name="scrollbars" id="scrollbars-off" value="false"> Disabled
-                    </label>
-                  </div>
                 </div>
               </div>
 

--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
             </span>
 
             <div class="flex-input">
-              <select id="deviceIDs" class="form-control">
+              <select id="deviceIDs" class="form-control c-select">
                 <option>--</option>
               </select>
             </div>
@@ -265,9 +265,9 @@
               <div class="form-group row">
                 <label for="autoscroll" class="col-sm-3 form-control-label">Auto-Scroll</label>
                 <div class="col-sm-9">
-                  <select name="autoscroll" id="autoscroll" class="form-control">
-                    <option value="pageBtm">When at page bottom</option>
+                  <select name="autoscroll" id="autoscroll" class="form-control c-select">
                     <option value="onEvent">When new events arrive</option>
+                    <option value="pageBtm">When at page bottom</option>
                     <option value="none">Never</option>
                   </select>
                 </div>
@@ -276,7 +276,7 @@
               <div class="form-group row">
                 <label for="lineends" class="col-sm-3 form-control-label">Line Endings</label>
                 <div class="col-sm-9">
-                  <select name="lineends" id="lineends" class="form-control">
+                  <select name="lineends" id="lineends" class="form-control c-select">
                     <option value="\r">\r</option>
                     <option value="\n">\n</option>
                     <option value="\r\n">\r\n</option>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="no-scroll-bars">
   <head>
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -226,24 +226,29 @@
       </div>
 
       <footer id="footer" class="container-fluid">
-        <div class="col-md-10">
-          <div class="flex-input">
-            <input type="text" class="form-control" id="senddata" placeholder="Send Data">
-            <button id="send" type="submit" class="btn btn-success hidden-sm-down"><i class="fa fa-paper-plane"></i> Send Data</button>
+        <form id="send-data-form">
+          <div class="col-md-10">
+            <div class="flex-input">
+              <input type="text" class="form-control" id="senddata" placeholder="Send Data">
+              <button id="send-lg" type="button" class="btn btn-success hidden-sm-down" data-submit>
+                <i class="fa fa-paper-plane"></i> Send Data
+              </button>
+            </div>
           </div>
-        </div>
 
-        <div class="col-md-2 col-xs-6 align-right sm-align-left">
-          <button class="btn btn-info"  data-toggle="modal" data-target="#modal-settings">
-            <i class="fa fa-cog"></i></button>
-          <button class="btn btn-secondary" id="logout" data-toggle="tooltip" data-placement="top" title="Sign Out">
-            <i class="fa fa-sign-out"></i></button>
-        </div>
+          <div class="col-md-2 col-xs-6 align-right sm-align-left">
+            <button type="button" class="btn btn-info"  data-toggle="modal" data-target="#modal-settings">
+              <i class="fa fa-cog"></i></button>
+            <button type="button" class="btn btn-secondary" id="logout" data-toggle="tooltip" data-placement="top" title="Sign Out">
+              <i class="fa fa-sign-out"></i></button>
+          </div>
 
-        <div class="col-xs-6 hidden-md-up align-right">
-          <button id="send" type="submit" class="btn btn-success"><i class="fa fa-paper-plane"></i> Send Data</button>
-        </div>
-
+          <div class="col-xs-6 hidden-md-up align-right">
+            <button id="send-sm" type="button" class="btn btn-success" data-submit>
+              <i class="fa fa-paper-plane"></i> Send Data
+            </button>
+          </div>
+        </form>
       </footer><!-- #footer -->
     </div><!-- #terminal -->
 
@@ -270,10 +275,10 @@
                 <label for="lineends" class="col-sm-3 form-control-label">Line Endings</label>
                 <div class="col-sm-9">
                   <select name="lineends" id="lineends" class="form-control">
-                    <option value="r">\r</option>
-                    <option value="n">\n</option>
-                    <option value="rn">\r\n</option>
-                    <option value="none">none</option>
+                    <option value="\r" selected>\r</option>
+                    <option value="\n">\n</option>
+                    <option value="\r\n">\r\n</option>
+                    <option value="false">none</option>
                   </select>
                 </div>
               </div>
@@ -281,14 +286,12 @@
               <div class="form-group row">
                 <label for="subenter" class="col-sm-3 form-control-label">Submit on Enter</label>
                 <div class="col-sm-9">
-                  <div class="c-inputs-stacked">
-                    <label class="c-input c-radio">
-                      <input id="subenter-on" name="subenter" type="radio" value="true">
-                      <span class="c-indicator"></span> Enabled
+                  <div class="btn-group" data-toggle="buttons">
+                    <label class="btn btn-secondary">
+                      <input type="radio" name="subenter" id="subenter-on" value="true"> Enabled
                     </label>
-                    <label class="c-input c-radio">
-                      <input id="subenter-off" name="subenter" type="radio" value="false">
-                      <span class="c-indicator"></span> Disabled
+                    <label class="btn btn-secondary">
+                      <input type="radio" name="subenter" id="subenter-off" value="false"> Disabled
                     </label>
                   </div>
                 </div>
@@ -410,6 +413,19 @@
                     </label>
                   </div>
                   <label for="show-devadm" class="form-control-sm form-control-label">Device admin</label>
+                </div>
+              </div>
+              <div class="form-group row">
+                <label for="scrollbars" class="col-sm-3 form-control-label">Visible Scroll Bars</label>
+                <div class="col-sm-9">
+                  <div class="btn-group" data-toggle="buttons">
+                    <label for="scrollbars-on" class="btn btn-secondary">
+                      <input type="radio" name="scrollbars" id="scrollbars-on" value="true"> Enabled
+                    </label>
+                    <label for="scrollbars-off" class="btn btn-secondary">
+                      <input type="radio" name="scrollbars" id="scrollbars-off" value="false"> Disabled
+                    </label>
+                  </div>
                 </div>
               </div>
 


### PR DESCRIPTION
This commit adds the final user settings functions: Autoscroll, Line endings, Submit-on-enter, and visible scroll bars.

Other major changes:
- Timestamp generation moved down to `terminal_print()` for simplicity
- "Send Data" form click handlers changed to allow for enter key delegation
- Disabled a few `console.log` statements to move away from debug clutter as we approach MVP
