### PR TITLE
Fix sidebar issues

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -114,12 +114,16 @@ body.modal-open::-webkit-scrollbar{ display: none }
   outline: 0;
 }
 .fixed-sidebar{
+  left: 0;
   color:#fff;
   position: fixed;
-  padding-top:70px;
-  padding-bottom:70px;
-  height:100%;
+  padding-top:10px;
+  padding-bottom:10px;
+  top: 70px;
+  bottom: 70px;
+  height: auto;
   overflow-y:auto;
+  overflow-x: hidden;
   z-index: 1;
 }
 .file-input-hidden [type="file"]{
@@ -263,5 +267,7 @@ label.btn {
   .fixed-sidebar{
     width:100%;
   }
-
+  html.sidebar-open{
+    overflow-y: hidden!important;
+  }
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -435,20 +435,17 @@ $(function() {
       .then(display_event);
   });
 
-  $('#sidebar').hover(function(){
-    $('body').css('overflow', 'hidden');
-  }, function(){
-    $('body').css('overflow', 'auto')
-  });
-
   $('#show-sidebar').on('click touch', function(e){
     e.preventDefault();
     $('.fixed-sidebar').toggleClass('open');
+    $('html').toggleClass('sidebar-open');
   });
 
   $('#content').on('click touch', function(){
-    if( $('#sidebar').hasClass('open'))
+    if( $('#sidebar').hasClass('open')){
       $('.fixed-sidebar').toggleClass('open');
+      $('html').toggleClass('sidebar-open');
+    }
   });
 
   $('#file-btn').click(function(){
@@ -740,10 +737,8 @@ function set_heights(){
   $("#content").css('padding-top', headerHeight+10);
   $("#content").css('padding-bottom', footerHeight+10);
 
-  if($(window).width() < 768){
-    $('.fixed-sidebar').css('padding-top', headerHeight+10)
-    $('.fixed-sidebar').css('padding-bottom', footerHeight+10)
-  }
+  $('.fixed-sidebar').css('top', headerHeight);
+  $('.fixed-sidebar').css('bottom', footerHeight);
 }
 
 $(window).resize(set_heights);


### PR DESCRIPTION
Removed sidebar hover js that was breaking sidebar select dropdowns in
Firefox. Resolves #66 .

Added "left: 0" to the css for fixed-sidebar, which keeps its scrollbar
onscreen when it has 100% width (previously, the sidebar was indented
slightly which pushed its scrollbar off screen). Also switched overflow
to hidden on the html element in this situation via a `sidebar-open`
class, otherwise the main content scrollbar is shown too. Resolves #72.

Changed the way the height of the fixed sidebar is defined so that it
spans only from the bottom of the header to the top of the footer.
Previously, the sidebar scrollbar would extend underneath the header and
footer to the edges of the window.
