### PR TITLE
Add draft licensing info

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,3 +1,12 @@
+// @licstart
+//
+// Copyright (C) 2016 Digistump LLC
+//
+// This file is licensed under the MIT License
+// A copy of this license may be found at http://opensource.org/licenses/MIT
+//
+// @licend
+
 /* Terminal Content */
 .selected{
   background-color: #1f8dd6;
@@ -269,6 +278,12 @@ a.func { color: #cfd2da;}
     color: #A0A0A0;
     margin-left: 5px;
     vertical-align: middle;
+}
+a.about-link  {
+  display: block;
+  padding-top: 0.75rem;
+  color: #cfd2da;
+  font-size: 75%;
 }
 
 label.btn {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,3 +1,9 @@
+// style.css
+// A component of OakTerm, a terminal app for the Digistump Oak
+// https://github.com/kh90909/OakTerm
+//
+// Authors: Ken Healy, Eric McNiece
+//
 // @licstart
 //
 // Copyright (C) 2016 Digistump LLC

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,3 +1,12 @@
+// @licstart
+//
+// Copyright (C) 2016 Digistump LLC
+//
+// This file is licensed under the MIT License
+// A copy of this license may be found at http://opensource.org/licenses/MIT
+//
+// @licend
+
 var consts = {
   ERR_MINOR: 'Minor',
   ERR_MAJOR: 'Major',

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,3 +1,9 @@
+// app.js
+// A component of OakTerm, a terminal app for the Digistump Oak
+// https://github.com/kh90909/OakTerm
+//
+// Authors: Ken Healy, Eric McNiece
+//
 // @licstart
 //
 // Copyright (C) 2016 Digistump LLC

--- a/index.html
+++ b/index.html
@@ -201,6 +201,12 @@
               </div>
             </div>
           </fieldset>
+
+          <fieldset class="form-group">
+            <a role="button" class="about-link" data-toggle="modal" data-target="#modal-about">
+              About OakTerm...
+            </a>
+          </fieldset>
         </div>
 
         <div id="content-background" class="col-md-9 col-md-push-3">
@@ -512,6 +518,25 @@
             <button type="button" id="modal-error-retry-button" class="btn btn-primary btn-default" data-dismiss="modal">Retry</button>
           </div>
         </div><!-- /.modal-content -->
+      </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
+
+    <div class="modal fade" id="modal-about">
+      <div class="modal-dialog" role="document">
+        <form id="rename-device">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h4 class="modal-title">About OakTerm</h4>
+            </div>
+            <div class="modal-body">
+              <p>Copyright &copy; 2016 Digistump LLC
+              <p>OakTerm is licensed under the <a rel="license" href="http://opensource.org/licenses/MIT">MIT License</a>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+            </div>
+            </div><!-- /.modal-content -->
+        </form>
       </div><!-- /.modal-dialog -->
     </div><!-- /.modal -->
 

--- a/index.html
+++ b/index.html
@@ -529,8 +529,12 @@
               <h4 class="modal-title">About OakTerm</h4>
             </div>
             <div class="modal-body">
+              <p>OakTerm is a terminal app for the Digistump Oak
+              <p>See the <a target="_blank" href="https://github.com/kh90909/OakTerm/blob/master/Readme.md">README</a> for a primer on usage. For further help and troubleshooting, go to the Digistump <a target="_blank" href="https://digistump.com/board/index.php?board=20.0">forums</a> and <a target="_blank" href="https://digistump.com/wiki/oak">wiki</a>. To view the code, report bugs, or contribute, check out the <a target="_blank" href="https://github.com/kh90909/OakTerm">project</a> on GitHub.
+              <p>--
+              <br>Developed by Ken Healy and Eric McNiece
               <p>Copyright &copy; 2016 Digistump LLC
-              <p>OakTerm is licensed under the <a rel="license" href="http://opensource.org/licenses/MIT">MIT License</a>
+              <br>OakTerm is licensed under the <a rel="license" target="_blank" href="http://opensource.org/licenses/MIT">MIT License</a>
             </div>
             <div class="modal-footer">
               <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>


### PR DESCRIPTION
The license statement is included in a comment at the top of the js and css sources, and placed in an "About OakTerm" modal in the html. (Most guidelines suggest the details should be visible to the user,
not hidden in a html comment).
